### PR TITLE
Source NTP queries from external-facing interface

### DIFF
--- a/roles/prepare-oob-server/files/ntp.conf
+++ b/roles/prepare-oob-server/files/ntp.conf
@@ -55,5 +55,6 @@ restrict ::1
 #broadcastclient
 
 # Specify interfaces, don't listen on switch ports
+interface listen eth0 # sources queries from AIR's external-facing interface
 interface listen eth1
 


### PR DESCRIPTION
For bootcamps running in AIR, we need to allow NTP on the `oob-mgmt-server` to source its queries from its external-facing interface (`eth0`). This way, the gateway is able to route responses back to the VM.